### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CODEOWNERS for jclee941/.github
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/managing-repository-settings/about-code-owners
+#
+# Order matters - the LAST matching pattern takes precedence.
+
+# Default owner
+*                                   @jclee941
+
+# Workflow + automation source of truth
+/.github/workflows/                 @jclee941
+/.github/dependabot.yml             @jclee941
+/scripts/                           @jclee941
+
+# pr-agent fork-local config
+/.pr_agent.toml                     @jclee941
+/pr_agent/settings/configuration.toml @jclee941
+
+# Security-sensitive
+/.github/workflows/security/        @jclee941
+/.github/workflows/codeql.yml       @jclee941
+/.github/workflows/gitleaks.yml     @jclee941
+/.github/CODEOWNERS                 @jclee941
+
+# Docs / templates
+/docs/                              @jclee941
+/AGENTS.md                          @jclee941
+/README.md                          @jclee941

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+PR 제목 형식 (Conventional Commits):
+  feat(scope): 새 기능
+  fix(scope): 버그 수정
+  docs(scope): 문서
+  refactor(scope): 리팩토링
+  test(scope): 테스트
+  chore(scope): 잡무
+  ci(scope): CI/CD
+  perf(scope): 성능
+  security(scope): 보안
+
+브랜치 이름: feat/* | fix/* | hotfix/* | docs/* | refactor/* | chore/* | ci/* | perf/* | security/* | test/*
+-->
+
+## Changes / 변경 사항
+
+<!-- 무엇을 / 왜 바꿨는지 한눈에 -->
+
+-
+-
+-
+
+## Why / 동기
+
+<!-- 이 변경이 필요한 이유. 이슈가 있다면 `Closes #N` 으로 연결 -->
+
+## How to verify / 검증 방법
+
+<!-- 리뷰어가 따라할 수 있는 구체적인 단계 -->
+
+```bash
+# 예) 로컬 검증 명령
+```
+
+## Risk / 영향 범위
+
+- [ ] 후방 호환성 영향 없음
+- [ ] 보안 영향 없음 (있다면 `security-review` 라벨 부착)
+- [ ] 다운스트림 11개 리포에 자동 동기화됨 (`scripts/deploy-to-repos.go` 변경 시)
+
+## Checklist
+
+- [ ] PR 제목이 Conventional Commits 규약 준수
+- [ ] 브랜치 이름이 표준 prefix 사용
+- [ ] 관련 문서 (README/AGENTS.md/docs/) 업데이트
+- [ ] 새 기능/설정 변경 시 예시 추가
+- [ ] 테스트 추가/갱신 (해당하는 경우)
+
+> 이 PR은 `jclee-bot`이 자동 리뷰합니다 (cli_proxy + Kimi-k2.6, 한국어 응답).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,29 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  # Python dependencies (pyproject.toml + requirements*.txt)
+  # Auto-merge policy in dependabot-auto-merge.yml: patch + minor → squash;
+  # major → manual review.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Go scripts (go.mod) - none yet, but ready when scripts/ gets a go.mod
+  # - package-ecosystem: "gomod"
+  #   directory: "/scripts"
+  #   schedule:
+  #     interval: "weekly"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,41 @@
+name: actionlint
+
+# Validates GitHub Actions workflow files for syntax + semantic errors
+# (shell injection risks, invalid expressions, dead branches, etc.).
+# sanity.yml only does `yaml.safe_load`, which is not enough.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [master, main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+
+      - name: Run actionlint
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+name: CodeQL
+
+# Static analysis security testing for Python sources.
+# Complements the AI-driven pr-review.yml by catching deterministic
+# security patterns (CWE Top 25) that LLMs can miss.
+
+on:
+  pull_request:
+    branches: [master, main]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'requirements*.txt'
+      - '.github/workflows/codeql.yml'
+  push:
+    branches: [master, main]
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+  schedule:
+    - cron: '23 4 * * 1'  # Mondays 04:23 UTC (off-peak)
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+          queries: security-extended,security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:python'

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,63 @@
+name: Gitleaks
+
+# Deterministic secret-pattern scan on every PR + push.
+# Complements auto-hardcode-scan.yml (weekly, regex-based) and
+# pr-review.yml (AI-based) by catching API keys, tokens, certs at gate time.
+#
+# Scope:
+#   - PR scans: gitleaks-action@v2 calls `gitleaks detect` over the PR commit
+#     range (`${baseRef}^..${headRef}` with --first-parent --no-merges). It
+#     reports leaks introduced by commits in this PR. It is NOT a strict
+#     base..head file-diff scan; secrets that appear and disappear within the
+#     PR commit series can still be flagged. Use `.gitleaksignore` for
+#     intentional fixtures.
+#   - Push scans: scans the new tip's reachable history.
+#
+# fetch-depth: 0 is REQUIRED for both events. The action references PR
+# commits by explicit SHA (${baseRef}^..${headRef}), so shallow clones can
+# break multi-commit PR scans. The upstream gitleaks-action README also
+# recommends fetch-depth: 0.
+#
+# Baseline: a repo-local `.gitleaks.toml` at the repository root is auto-
+# detected by the gitleaks CLI. Do NOT set GITLEAKS_CONFIG to a path that
+# might not exist - that hard-fails the action across all downstream repos.
+# When deploying to a downstream repo with pre-existing historical findings,
+# add a `.gitleaksignore` (one fingerprint per line) instead of blocking the
+# required check.
+
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: gitleaks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GITLEAKS_LICENSE only required for organization-scope scanning.
+          GITLEAKS_NOTIFY_USER_LIST: '@jclee941'
+          GITLEAKS_ENABLE_COMMENTS: 'true'
+          GITLEAKS_ENABLE_SUMMARY: 'true'
+          # GITLEAKS_CONFIG intentionally unset - gitleaks CLI auto-detects
+          # repo-local .gitleaks.toml. Setting it to a non-existent path
+          # would hard-fail the action across all downstream repos.

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -17,6 +17,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr_review:
     if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
@@ -84,11 +88,13 @@ jobs:
           CONFIG.FALLBACK_MODELS: '["kimi-k2.5", "claude-sonnet-4-6"]'
           CONFIG.RESPONSE_LANGUAGE: ko
           CONFIG.AI_TIMEOUT: "180"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Tell pr-agent to review the upstream caller's PR, not this repo's.
-          # Note: env names with dots (e.g. GITHUB.PR_URL) are valid for
-          # pr-agent settings via dynaconf, but bash cannot expand them.
-          # Use a shell-safe alias for the run step instead.
+          GITHUB__USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # NOTE: Dynaconf maps `GITHUB__USER_TOKEN` (double underscore) to the nested setting
+          # `settings.github.user_token` because pr-agent's config_loader uses `envvar_prefix=False`
+          # with the standard env_loader. Dot-notation names (e.g. `GITHUB.USER_TOKEN`) are NOT
+          # POSIX-valid identifiers; bash cannot `export` them. GitHub Actions can sometimes inject
+          # them anyway, but rely on the documented dynaconf double-underscore convention to keep
+          # the workflow portable to any runner.
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_REVIEWER.EXTRA_INSTRUCTIONS: |
             이 리뷰는 표준 코드 리뷰 모드입니다.
@@ -105,4 +111,33 @@ jobs:
 
           PR_DESCRIPTION.EXTRA_INSTRUCTIONS: |
             PR 설명은 한국어로 작성하십시오.
-        run: .venv/bin/python -m pr_agent.cli --pr_url "$PR_URL" review
+        run: |
+          set -eo pipefail
+
+          # Preflight: confirm dynaconf actually loaded the GitHub token
+          .venv/bin/python - <<'PY'
+          from pr_agent.config_loader import get_settings
+          tok = get_settings().get("github.user_token")
+          if not tok:
+              raise SystemExit("ERROR: settings.github.user_token is empty. "
+                               "Confirm GITHUB__USER_TOKEN env var is exported.")
+          print("preflight ok: github.user_token configured")
+          PY
+
+          # Run the review and capture both pr-agent's exit code and its log output.
+          # pr-agent's CLI exits 0 even on fatal provider errors (silent-success), so we
+          # additionally grep the captured log for known fatal patterns and fail the job.
+          set +e
+          .venv/bin/python -m pr_agent.cli --pr_url "$PR_URL" review 2>&1 | tee /tmp/pr-agent.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$status" -ne 0 ]; then
+            echo "::error::pr-agent CLI exited with status $status"
+            exit "$status"
+          fi
+
+          if grep -E "BoxKeyError|GitHub token is required|Failed to get git provider|Traceback" /tmp/pr-agent.log; then
+            echo "::error::pr-agent reported a fatal error but exited 0 (silent failure)"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run scripts/branch-protection.go --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.
