### PR TITLE
test: final LLM review probe on tmux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ thoughts/
 node_modules/
 .sisyphus/
 .cursor/
+<!-- LLM final probe 1777812018 -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,3 +337,5 @@ source ~/.tmux/bin/tmux-bash-preexec
 - `tmux-resurrect-save.service` triggers save before shutdown; software-only solution (power loss requires UPS)
 - 37 bash scripts in `bin/` totaling ~1782 LOC; 4 shared libraries in `bin/lib/` totaling ~329 LOC
 - 6 conf files in `conf.d/` totaling ~242 LOC
+
+<!-- LLM final probe 1777812678 -->


### PR DESCRIPTION
Final probe after all 3 stages of fixes:
1. GITHUB__USER_TOKEN (dynaconf nested key for github.user_token)
2. OPENAI.KEY (litellm api_key path - was OPENAI_KEY single-underscore)
3. CONFIG.CUSTOM_MODEL_MAX_TOKENS=128000 (kimi/claude not in MAX_TOKENS table)

Expected: github-actions[bot] posts a Korean LLM review comment within ~90s.