### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -41,7 +41,6 @@ jobs:
           rm /tmp/actionlint.tar.gz
           ./actionlint --version
         shell: bash
-        shell: bash
 
       - name: Run actionlint
         run: |

--- a/.github/workflows/ci-failure-issues.yml
+++ b/.github/workflows/ci-failure-issues.yml
@@ -49,7 +49,6 @@ permissions:
 concurrency:
   group: ci-failure-issues-${{ github.event.workflow_run.head_sha || inputs.head_sha || github.run_id }}
   cancel-in-progress: false
-  cancel-in-progress: false
 
 jobs:
   triage:
@@ -106,31 +105,6 @@ jobs:
             exit 1
           fi
 
-          {
-            echo "wf_name=$WF_NAME"
-            echo "head_sha=$HEAD_SHA"
-            echo "run_id=$RUN_ID"
-            echo "conclusion=$CONCLUSION"
-            echo "short_sha=${HEAD_SHA:0:8}"
-            echo "pr_number=$PR_NUMBER"
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -eu
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            WF_NAME="${{ inputs.workflow_name }}"
-            HEAD_SHA="${{ inputs.head_sha }}"
-            RUN_ID="${{ inputs.run_id }}"
-            CONCLUSION="${{ inputs.conclusion }}"
-            PR_NUMBER="${{ inputs.pr_number || '0' }}"
-          else
-            WF_NAME='${{ github.event.workflow_run.name }}'
-            HEAD_SHA='${{ github.event.workflow_run.head_sha }}'
-            RUN_ID='${{ github.event.workflow_run.id }}'
-            CONCLUSION='${{ github.event.workflow_run.conclusion }}'
-            PR_NUMBER='${{ github.event.workflow_run.pull_requests[0].number || '0' }}'
-          fi
           {
             echo "wf_name=$WF_NAME"
             echo "head_sha=$HEAD_SHA"


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- `actionlint.yml` 및 `ci-failure-issues.yml` 중복 항목 제거

- `actionlint.yml`에서 `shell: bash` 중복 선언 제거

- `ci-failure-issues.yml`의 `cancel-in-progress` 및 스크립트 블록 중복 제거


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actionlint.yml`</strong><dd><code>actionlint 워크플로우 중복 shell 키 제거</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/actionlint.yml`

- 실행 단계에서 `shell: bash`가 두 번 선언된 중복 키 제거


</details>


  </td>
  <td><a href=""></a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ci-failure-issues.yml`</strong><dd><code>ci-failure 워크플로우 중복 블록 정리</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

`.github/workflows/ci-failure-issues.yml`

<ul><li><code>concurrency</code> 그룹 내 <code>cancel-in-progress: false</code> 중복 선언 제거<br> <li> 동일한 내용의 <code>env</code> 및 <code>run</code> 스크립트 블록 중복 제거</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

