### PR TITLE
chore: standardize automation workflows + dependabot config

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -44,7 +44,7 @@ jobs:
   scan:
     # Gitleaks does not need self-hosted resources; ubuntu-latest avoids
     # gitleaks-action@v2 install failures on self-hosted runners.
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-pr-checks.yml
+++ b/.github/workflows/reusable-pr-checks.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   check-size:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Size
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   check-title:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Title
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   check-branch:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Branch Name
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   check-description:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check PR Description
     steps:
@@ -144,7 +144,7 @@ jobs:
 
   check-large-files:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Large Files
     steps:
@@ -181,7 +181,7 @@ jobs:
 
   check-sensitive-files:
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted
+    runs-on: ${{ github.repository_visibility == 'private' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 10
     name: Check Sensitive Files
     steps:


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **Issue management + docs sync** workflows.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`gitleaks.yml`, `codeql.yml`, `actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Enhancement


___

### **Description**
- Gitleaks 및 PR 검사 워크플로우 실행환경 조건부 설정

- 비공개 저장소는 `self-hosted`, 공개는 `ubuntu-latest` 사용

- PR 체크 및 Gitleaks 스캔 실행환경 일괄 변경


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Trigger"] --> B{"Repository Visibility"}
  B -- "private" --> C["self-hosted runner"]
  B -- "public" --> D["ubuntu-latest runner"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gitleaks.yml</strong><dd><code>Gitleaks 스캔 작업 실행환경 조건부 설정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/gitleaks.yml

<ul><li><code>runs-on</code>을 저장소 가시성에 따라 동적으로 변경<br> <li> 비공개 저장소는 <code>self-hosted</code>, 공개 저장소는 <code>ubuntu-latest</code> 사용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/tmux/pull/68/files#diff-2aa7a05eafb406b4c582ed3bd35f2ef3a6fadeaad31372f62a79bd7610e1e453">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>reusable-pr-checks.yml</strong><dd><code>6개 PR 체크 작업 실행환경 조건부 설정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/reusable-pr-checks.yml

<ul><li><code>check-size</code>, <code>check-title</code>, <code>check-branch</code>, <code>check-description</code>, <br><code>check-large-files</code>, <code>check-sensitive-files</code> 작업의 <code>runs-on</code> 변경<br> <li> <code>github.repository_visibility == 'private'</code> 조건으로 실행환경 분기<br> <li> 비공개 저장소는 <code>self-hosted</code>, 공개 저장소는 <code>ubuntu-latest</code> 사용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/tmux/pull/68/files#diff-c847d70b033c8a55778bee6b336f27519c76efbe8d9f7b8c67108ef006d42ee7">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

