### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/29_downstream-health-check.yml
+++ b/.github/workflows/29_downstream-health-check.yml
@@ -29,18 +29,20 @@ jobs:
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
-      - name: Checkout repository inventory
-        uses: actions/checkout@v6
-        with:
-          repository: jclee941/.github
-          path: .github-inventory
-
+      # Default-path checkout MUST come first: actions/checkout cleans the
+      # workspace root, which would wipe a previously-checked-out subdir.
       - name: Checkout local actions
         uses: actions/checkout@v6
         with:
           repository: jclee941/.github
           ref: master
           fetch-depth: 1
+
+      - name: Checkout repository inventory
+        uses: actions/checkout@v6
+        with:
+          repository: jclee941/.github
+          path: .github-inventory
 
       - name: Check latest workflow runs across all repos
         id: health


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- checkout 단계 순서를 수정하여 작업 공간 보호

- 기본 경로 체크아웃을 하위 디렉터리 체크아웃보다 먼저 실행

- 작업 공간 초기화로 인한 데이터 손실 가능성 방지


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["기존 순서:<br/>inventory 체크아웃 먼저"] --> B["문제:<br/>workspace 정리로 하위 디렉터리 삭제"]
    C["변경된 순서:<br/>local actions 먼저 체크아웃"] --> D["하위 디렉터리 inventory<br/>정상 체크아웃 완료"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>29_downstream-health-check.yml</strong><dd><code>checkout 단계 순서 변경으로 작업 공간 초기화 문제 방지</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/29_downstream-health-check.yml

<ul><li><code>actions/checkout</code> 단계의 실행 순서를 변경하여 기본 경로 체크아웃을 먼저 수행하도록 수정<br> <li> 기본 경로 체크아웃이 나중에 이루어지면 작업 공간 정리 시 이전에 체크아웃한 하위 디렉터리가 삭제될 수 있는 잠재적 문제 해결<br> <li> 순서 변경의 이유를 설명하는 주석 추가</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/tmux/pull/165/files#diff-0a2d1fa5e4f41ad7db3bbc643780738a3f440dc3f1b0731eb925db7fd7369f9b">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

