### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/20_readme-gen.yml
+++ b/.github/workflows/20_readme-gen.yml
@@ -78,13 +78,23 @@ jobs:
           set -eu
           git config user.email "bot@jclee.me"
           git config user.name "github-bot"
-          git checkout -b bot/auto-readme-update
+          # Re-create the bot branch from the freshly generated state.
+          # checkout -B is idempotent across repeated runs (fixed branch name),
+          # and --force below handles both the first run (no remote branch yet)
+          # and re-runs (existing remote branch) without a 'stale info' lease
+          # error. This is a bot-owned branch with the bot as sole writer, and
+          # the workflow concurrency group serialises runs, so --force is safe.
+          git checkout -B bot/auto-readme-update
           git add README.md
-          git commit -m "docs: auto-update README.md [skip ci]"
+          # No [skip ci]: the PR needs its required checks to run so auto-merge
+          # can be satisfied.
+          git commit -m "docs: auto-update README.md"
           gh auth setup-git
-          git push -u origin bot/auto-readme-update --force-with-lease
+          git push -u origin bot/auto-readme-update --force
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (not GITHUB_TOKEN) so the pushed branch triggers PR checks and
+          # auto-merge can fire.
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Create or update PR
         if: steps.diff.outputs.changed == 'true'
@@ -101,7 +111,7 @@ jobs:
               --head bot/auto-readme-update
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true'
@@ -110,7 +120,7 @@ jobs:
           pr_number=$(gh pr list --head bot/auto-readme-update --json number --jq '.[0].number')
           gh pr merge "$pr_number" --auto --squash
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
       - name: Notify on failure
         if: failure()
         uses: ./.github/actions/notify-on-failure


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- PR 체크 트리거를 위해 PAT 토큰 사용

- 봇 브랜치 재생성 시 idempotency 확보

- `[skip ci]` 제거로 필수 체크 통과 가능

- `force-with-lease`를 `force`로 변경해 반복 실행 안정화


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["README diff 감지"] --> B["checkout -B<br>봇 브랜치 재생성"]
  B --> C["PAT로 push<br>--force"]
  C --> D["PR 생성/수정<br>auto-merge 활성화"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>20_readme-gen.yml</strong><dd><code>README 생성 워크플로우의 PAT 및 브랜치 처리 수정</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/20_readme-gen.yml

<ul><li><code>git checkout -b</code>를 <code>-B</code>로 변경하여 반복 실행 시에도 브랜치를 안정적으로 재생성<br> <li> 커밋 메시지에서 <code>[skip ci]</code> 제거하여 PR 필수 체크가 실행되도록 수정<br> <li> <code>git push --force-with-lease</code>를 <code>--force</code>로 변경하고 주석 추가<br> <li> <code>secrets.GITHUB_TOKEN</code>을 <code>secrets.GH_PAT || secrets.GITHUB_TOKEN</code>으로 변경하여 <br>PAT 우선 사용</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/tmux/pull/173/files#diff-3151312623e64c1035ee16621695ce8cf19800d6f70cb01f238c4d309d518c5a">+16/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

