### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/37_ci-failure-issues.yml
+++ b/.github/workflows/37_ci-failure-issues.yml
@@ -168,6 +168,48 @@ jobs:
               || echo "::warning::failed to close #$N; continuing"
           done
 
+      - name: On success, close stable-titled health/scan issues for this workflow
+        if: steps.ev.outputs.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WF_NAME: ${{ steps.ev.outputs.wf_name }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          set -euo pipefail
+          # Map the recovered workflow NAME -> title substrings of the stable
+          # (and legacy) failure/health issues it creates. On success, close
+          # them immediately (event-driven), complementing the daily sweep.
+          case "$WF_NAME" in
+            "Gitleaks") SUBS='Gitleaks Scan Failed' ;;
+            "CodeQL") SUBS='CodeQL Analysis Failed' ;;
+            "ELK Health Check") SUBS='ELK Health Check Failed' ;;
+            "ELK Setup") SUBS='ELK Setup Failed' ;;
+            "Runtime Health Check") SUBS=$(printf '%s\n' 'Bot webhook endpoint unreachable' 'CLIProxyAPI unreachable' 'jclee-bot not responding' 'Runtime Health Check failed') ;;
+            "Downstream Health Check") SUBS=$(printf '%s\n' 'Downstream workflow failures detected' 'Downstream Health Check failed') ;;
+            "Bot Health Monitor") SUBS=$(printf '%s\n' 'bot-health' 'Bot Health Monitor failed') ;;
+            "Drift Detector") SUBS='Drift Detector Failed' ;;
+            "CI Auto-Heal") SUBS=$(printf '%s\n' 'CI failure:' 'CI Auto-Heal failed') ;;
+            *) echo "::notice::No stable-title mapping for '$WF_NAME'; nothing to close here"; exit 0 ;;
+          esac
+          printf '%s\n' "$SUBS" | while IFS= read -r sub; do
+            [ -z "$sub" ] && continue
+            ids=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+              --search "in:title \"$sub\"" --limit 100 \
+              --json number --jq '.[].number' 2>/dev/null || true)
+            [ -z "$ids" ] && continue
+            for n in $ids; do
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "::notice::DRY-RUN: would close #$n ($WF_NAME recovered)"
+                continue
+              fi
+              gh issue close "$n" --repo "$GITHUB_REPOSITORY" \
+                --comment "Resolved: $WF_NAME concluded success. Auto-closed by jclee-bot (event-driven recovery)." \
+                --reason completed \
+                && echo "::notice::Closed #$n ($WF_NAME recovered)" \
+                || echo "::warning::failed to close #$n; continuing"
+            done
+          done
+
       - name: On success, close legacy auto-deploy failure issues
         if: steps.ev.outputs.conclusion == 'success' && steps.ev.outputs.wf_name == 'Auto Deploy Workflows'
         env:
@@ -283,22 +325,46 @@ jobs:
           # Map a title-substring -> workflow file. A stale issue whose title
           # contains the key is auto-closed iff that workflow's latest
           # completed run on the default branch concluded 'success'.
+          # Includes BOTH current stable titles and legacy per-run-id titles
+          # so historical spam issues are also swept.
           # Format: '<title-substring>|<workflow-file>'
           MAP="$(printf '%s\n' \
             'Gitleaks Scan Failed|05_gitleaks.yml' \
-            'Runtime Health Check failed|30_runtime-health-check.yml' \
+            'CodeQL Analysis Failed|06_codeql.yml' \
             'ELK Health Check Failed|26_elk-health-check.yml' \
+            'ELK Setup Failed|27_elk-setup.yml' \
+            'Bot webhook endpoint unreachable|30_runtime-health-check.yml' \
+            'CLIProxyAPI unreachable|30_runtime-health-check.yml' \
+            'jclee-bot not responding|30_runtime-health-check.yml' \
+            'Runtime Health Check failed|30_runtime-health-check.yml' \
+            'Downstream workflow failures detected|29_downstream-health-check.yml' \
             'Downstream Health Check failed|29_downstream-health-check.yml' \
-            'Bot Health|28_bot-health-monitor.yml' \
+            'bot-health|28_bot-health-monitor.yml' \
+            'Bot Health Monitor failed|28_bot-health-monitor.yml' \
+            'CI failure:|60_ci-auto-heal.yml' \
             'CI Auto-Heal failed|60_ci-auto-heal.yml' \
+            'Drift Detector Failed|33_drift-detector.yml' \
             'Repository Health Check|31_repo-health.yml')"
 
-          # Cache each workflow's latest completed run conclusion.
+          # Latest COMPLETED run conclusion for a workflow on the default branch.
           latest_conclusion() {
             wf_file="$1"
             # Query-string form forces a GET; -f would make gh send a POST (404).
             gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$wf_file/runs?branch=$DEFAULT_BRANCH&status=completed&per_page=1" \
               --jq '.workflow_runs[0].conclusion // "none"' 2>/dev/null || echo "error"
+          }
+
+          # Whether the NEWEST run (any status) is still in flight. If a fresh
+          # run is queued/in-progress we hold off closing until it completes,
+          # so we never close based on a stale success while a new run runs.
+          newest_in_flight() {
+            wf_file="$1"
+            status=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$wf_file/runs?branch=$DEFAULT_BRANCH&per_page=1" \
+              --jq '.workflow_runs[0].status // "none"' 2>/dev/null || echo "error")
+            case "$status" in
+              queued|in_progress|waiting|pending|requested) return 0 ;;
+              *) return 1 ;;
+            esac
           }
 
           # Note: the loop runs in a pipeline subshell, so per-close logging
@@ -309,6 +375,10 @@ jobs:
               --search "in:title \"$substr\"" --limit 100 \
               --json number,title --jq '.[].number' 2>/dev/null || true)
             [ -z "$issues" ] && continue
+            if newest_in_flight "$wf_file"; then
+              echo "::notice::$wf_file has a run in flight; deferring close of its open issues"
+              continue
+            fi
             conclusion=$(latest_conclusion "$wf_file")
             if [ "$conclusion" != "success" ]; then
               echo "::notice::$wf_file latest run conclusion=$conclusion; keeping its open issues"


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
enhancement


___

### **Description**
- CI 실패 이슈 자동 종료 워크플로우에 성공 시 event-driven으로 stable-title 이슈를 즉시 닫는 새 단계 추가

- Gitleaks, CodeQL, ELK, Runtime/Downstream/Bot Health Check, Drift Detector, CI Auto-Heal 등의 워크플로우 매핑 확장

- `newest_in_flight()` 함수 추가: 진행 중인 run이 있으면 이슈 닫기를 보류하여 stale success 방지


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Workflow Success] --> B{37_ci-failure-issues.yml}
  B --> C[Event-driven: Close stable-title issues]
  B --> D[Daily sweep: Check latest conclusion]
  C --> E["Map WF_NAME → Title substrings"]
  D --> F{newest_in_flight?}
  F -->|Yes| G[Defer close]
  F -->|No| H{latest_conclusion == success?}
  H -->|Yes| I[Close matching issues]
  H -->|No| J[Keep issues open]
  E --> K[Gitleaks, CodeQL, ELK...]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>37_ci-failure-issues.yml</strong><dd><code>Event-driven stable-title 이슈 닫기 및 in-flight 检测 구현</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/37_ci-failure-issues.yml

<ul><li>성공 이벤트 시 stable-title health/scan 이슈를 즉시 닫는 event-driven 로직 추가 <br>(wf_name 매핑 기반)<br> <li> 기존 daily sweep 로직의 title substrings 맵 확장 (CodeQL, ELK Setup, Drift <br>Detector, Bot Health 등 추가)<br> <li> <code>newest_in_flight()</code> 함수 추가: queued/in_progress 상태 워크플로우의 이슈 닫기 보류<br> <li> Dry-run 모드 지원 및 닫힌 이슈에コメント 기록</ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/tmux/pull/215/files#diff-b7915627bf5a3f819200e450f76d18990ded0c290cd731ef75bbb887a26bc3f9">+73/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

