### PR TITLE
chore: sync automation workflows, dependabot, and templates

### DIFF
--- a/.github/workflows/45_reusable-gitleaks.yml
+++ b/.github/workflows/45_reusable-gitleaks.yml
@@ -71,10 +71,13 @@ jobs:
             echo "::error::gitleaks download failed or produced an empty file" >&2
             exit 1
           fi
-          mkdir -p "$HOME/.local/bin"
-          tar -xzf /tmp/gitleaks.tar.gz -C "$HOME/.local/bin" gitleaks
-          chmod +x "$HOME/.local/bin/gitleaks"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # The self-hosted runner may have HOME unset; under `set -u` a bare
+          # $HOME aborts the step. Use a default-expanded install dir.
+          BIN_DIR="${HOME:-/usr/local}/.local/bin"
+          mkdir -p "$BIN_DIR"
+          tar -xzf /tmp/gitleaks.tar.gz -C "$BIN_DIR" gitleaks
+          chmod +x "$BIN_DIR/gitleaks"
+          echo "$BIN_DIR" >> "$GITHUB_PATH"
 
       - name: Run gitleaks detect
         run: |


### PR DESCRIPTION
### **User description**
## Summary

Sync standard automation from `jclee941/.github`:

- **PR checks** (size, title, branch name, description, large files, sensitive files) - 2 enforcing + 4 advisory contexts.
- **Auto-review** via cli_proxy on every non-draft PR (Dependabot PRs are reviewed by `12_dependabot-auto-merge.yml` instead).
- **Dependabot auto-merge** for patch + minor + github_actions updates; majors and unknown update-types are commented for manual review.
- **CodeQL** (Python SAST), **Gitleaks** (secret scanning), **actionlint** (workflow YAML linter).
- **`.github/dependabot.yml`** schedules weekly `github-actions` + `pip` ecosystem updates. (`pip` will warn 'no manifest found' on non-Python repos; safe to ignore until Python is added.)
- **`.github/CODEOWNERS`** + **`.github/PULL_REQUEST_TEMPLATE.md`** - per-repo files (org-level CODEOWNERS does NOT propagate).
- **`.github/ISSUE_TEMPLATE/`** — standardized bug reports, feature requests, and security vulnerability templates.
- **Issue management + docs sync** workflows — markdown lint, link check, README sync validation, API docs check.
- **README generator** (`20_readme-gen.yml`) — auto-generates README.md via CLIProxyAPI (minimax-m2.7 → gpt-5.5 fallback).
- **Template sync** (`template-sync.yml`) — deploys standard `README.md`, `CONTRIBUTING.md`, `LICENSE` templates.

Deployed by `scripts/deploy-to-repos.go` from `jclee941/.github`. See [AGENTS.md § GIT FLOW AUTOMATION](https://github.com/jclee941/.github/blob/master/AGENTS.md#git-flow-automation) for the inventory and policy.

## Rollout sequence (REQUIRED ORDER - do not skip)

1. **Merge this PR** — the new workflows (`05_gitleaks.yml`, `06_codeql.yml`, `04_actionlint.yml`) start running on subsequent PRs as **advisory** checks. They are NOT yet required.
2. **Confirm `Gitleaks / scan` is green** — open one trivial test PR (or wait for the next real PR) and verify the Gitleaks job passes. If the repo has historical leaks, `gitleaks` will fail. In that case add a `.gitleaksignore` (one fingerprint per line) or a repo-local `.gitleaks.toml` allowlist, commit it, and re-run.
3. **Apply branch protection** — only after step 2 succeeds, run from `jclee941/.github`:
   ```
   go run ./scripts/cmd/branch-protection --repos=<this-repo>
   ```
   This registers `Gitleaks / scan` as a third required status check (alongside the two existing `pr-checks` contexts). Skipping step 2 will deadlock all subsequent PRs (including Dependabot) on a missing required check.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `gitleaks` workflow to handle self-hosted runners where `HOME` environment variable may be unset

- Use `${HOME:-/usr/local}` as fallback for install directory instead of bare `$HOME`

- Prevents workflow failure under `set -eu` when `HOME` is empty/unset


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["run: gitleaks detect<br/>set -eu"] --> B{HOME set?}
  B -->|Yes| C["\$HOME/.local/bin"]
  B -->|No/Empty| D["/usr/local/.local/bin"]
  C --> E["Success"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>45_reusable-gitleaks.yml</strong><dd><code>Fix gitleaks install path for self-hosted runners</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/45_reusable-gitleaks.yml

<ul><li>Add <code>${HOME:-/usr/local}</code> fallback for <code>BIN_DIR</code> to handle unset HOME on <br>self-hosted runners<br> <li> Replace hardcoded <code>$HOME/.local/bin</code> with dynamic <code>BIN_DIR</code> variable<br> <li> Update mkdir, tar, chmod, and GITHUB_PATH commands to use <code>BIN_DIR</code></ul>


</details>


  </td>
  <td><a href="https://github.com/jclee941/tmux/pull/290/files#diff-b0c214cbba4f66a13fff736b9ecc79f46a529587bb37cb1ced1d6c7c60f062c7">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

